### PR TITLE
Add backlog-cli to Terraform management

### DIFF
--- a/terraform/repositories.tf
+++ b/terraform/repositories.tf
@@ -74,6 +74,11 @@ locals {
       auto_init   = false
     }
 
+    "backlog-cli" = {
+      description = "An unofficial CLI tool for Backlog"
+      auto_init   = false
+    }
+
     "claude-config" = {
       description              = ""
       topics                   = []


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Checklist

### Before Review

- [x] Status checks are passing
- [x] Target branch is `main`

### After Approval

- [x] `mise run tf-apply` has succeeded

## Summary

- `backlog-cli` リポジトリを Terraform 管理に追加
- Description: "An unofficial CLI tool for Backlog"
- 既存リポジトリのため `auto_init = false`

## Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for backlog-cli, an unofficial CLI tool for Backlog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->