### PR TITLE
Add GitHub Pages (Actions) configuration for backlog-cli

### DIFF
--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -28,10 +28,10 @@ resource "github_repository" "this" {
   license_template   = lookup(var.config, "license_template", var.license_template)
 
   dynamic "pages" {
-    for_each = lookup(var.config, "pages", null) != null ? [lookup(var.config, "pages", {})] : []
+    for_each = lookup(var.config, "enable_pages", false) ? [1] : []
 
     content {
-      build_type = lookup(pages.value, "build_type", "workflow")
+      build_type = "workflow"
     }
   }
 

--- a/terraform/repositories.tf
+++ b/terraform/repositories.tf
@@ -79,9 +79,7 @@ locals {
       homepage_url = "https://23prime.github.io/backlog-cli/"
       topics       = ["cli", "rust", "nulab", "backlog"]
       auto_init    = false
-      pages = {
-        build_type = "workflow"
-      }
+      enable_pages = true
     }
 
     "claude-config" = {


### PR DESCRIPTION
## Checklist

### Before Review

- [x] Status checks are passing
- [x] Target branch is `main`

### After Approval

- [x] `mise run tf-apply` has succeeded

## Summary

- Add `pages` dynamic block to `terraform/modules/repository/main.tf` to support GitHub Pages configuration in the repository module
- Add `enable_pages = true` to `backlog-cli` in `terraform/repositories.tf` to enable publishing via GitHub Actions (`build_type = "workflow"`)

## Notes

Only GitHub Actions (`workflow`) build type is supported. The `enable_pages` flag is a simple boolean with no sub-configuration needed.