### PR TITLE
Allow all branches and tags to deploy to github-pages environment

### DIFF
--- a/terraform/modules/repository/environments.tf
+++ b/terraform/modules/repository/environments.tf
@@ -4,8 +4,4 @@ resource "github_repository_environment" "github_pages" {
   environment = "github-pages"
   repository  = github_repository.this.name
 
-  deployment_branch_policy {
-    protected_branches     = false
-    custom_branch_policies = false
-  }
 }


### PR DESCRIPTION
## Checklist

### Before Review

- [x] Status checks are passing
- [x] Target branch is `main`

### After Approval

- [x] `mise run tf-apply` has succeeded

## Summary

- Add `environments.tf` to the repository module to configure the `github-pages` environment when `enable_pages = true`
- Set `protected_branches = false` and `custom_branch_policies = false` to allow all branches and tags to deploy, fixing the error: `Tag "v0.x.x" is not allowed to deploy to github-pages due to environment protection rules`

## Notes

This is a follow-up to #48.