### PR TITLE
chore: use aqua backend for terraform instead of asdf

### DIFF
--- a/.github/workflows/check-terraform.yml
+++ b/.github/workflows/check-terraform.yml
@@ -35,18 +35,9 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           install: true
-          install_args: "terraform"
+          install_args: "aqua:hashicorp/terraform"
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Workaround for https://github.com/jdx/mise-action/issues/175
-      # The asdf:terraform backend installs the binary at the root of the install dir,
-      # but mise env reports the /bin subdirectory in PATH. Create a symlink to fix this.
-      - name: Fix terraform bin path
-        run: |
-          INSTALL_DIR=$(find ~/.local/share/mise/installs/terraform -maxdepth 1 -mindepth 1 -type d | head -1)
-          mkdir -p "${INSTALL_DIR}/bin"
-          ln -sf "${INSTALL_DIR}/terraform" "${INSTALL_DIR}/bin/terraform"
 
       - name: Initialize Terraform (without backend)
         run: mise run tf-init-nobackend

--- a/mise.lock
+++ b/mise.lock
@@ -46,6 +46,10 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924919"
 provenance = "github-attestations"
 
+[[tools."aqua:hashicorp/terraform"]]
+version = "1.15.7"
+backend = "aqua:hashicorp/terraform"
+
 [[tools.betterleaks]]
 version = "v1.6.1"
 backend = "aqua:betterleaks/betterleaks"

--- a/mise.lock
+++ b/mise.lock
@@ -50,6 +50,34 @@ provenance = "github-attestations"
 version = "1.15.7"
 backend = "aqua:hashicorp/terraform"
 
+[tools."aqua:hashicorp/terraform"."platforms.linux-arm64"]
+checksum = "sha256:7a9e92105ede978cf9049a2fbe53dfe67c6a8da4b4d7f613d89e7dd7c63ec40d"
+url = "https://releases.hashicorp.com/terraform/1.15.7/terraform_1.15.7_linux_arm64.zip"
+
+[tools."aqua:hashicorp/terraform"."platforms.linux-arm64-musl"]
+checksum = "sha256:7a9e92105ede978cf9049a2fbe53dfe67c6a8da4b4d7f613d89e7dd7c63ec40d"
+url = "https://releases.hashicorp.com/terraform/1.15.7/terraform_1.15.7_linux_arm64.zip"
+
+[tools."aqua:hashicorp/terraform"."platforms.linux-x64"]
+checksum = "sha256:73bbb8f5188ad75d4fb853fd100ae4d7e146ef7af7db18776109642fdb7759d2"
+url = "https://releases.hashicorp.com/terraform/1.15.7/terraform_1.15.7_linux_amd64.zip"
+
+[tools."aqua:hashicorp/terraform"."platforms.linux-x64-musl"]
+checksum = "sha256:73bbb8f5188ad75d4fb853fd100ae4d7e146ef7af7db18776109642fdb7759d2"
+url = "https://releases.hashicorp.com/terraform/1.15.7/terraform_1.15.7_linux_amd64.zip"
+
+[tools."aqua:hashicorp/terraform"."platforms.macos-arm64"]
+checksum = "sha256:711791bf41365137a9a4adbf3e4c4a18dd7389d45c6a3039e3c6946bc750080e"
+url = "https://releases.hashicorp.com/terraform/1.15.7/terraform_1.15.7_darwin_arm64.zip"
+
+[tools."aqua:hashicorp/terraform"."platforms.macos-x64"]
+checksum = "sha256:7f7a055e4d0c9dddb19cb14058fc885df139fdd4e987fffff6bf82993ac6a1a3"
+url = "https://releases.hashicorp.com/terraform/1.15.7/terraform_1.15.7_darwin_amd64.zip"
+
+[tools."aqua:hashicorp/terraform"."platforms.windows-x64"]
+checksum = "sha256:1644891f1d02dea989daed9a39c564ebdc80e13c9a7e42e713fba84d7f53b8f6"
+url = "https://releases.hashicorp.com/terraform/1.15.7/terraform_1.15.7_windows_amd64.zip"
+
 [[tools.betterleaks]]
 version = "v1.6.1"
 backend = "aqua:betterleaks/betterleaks"

--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,7 @@ lefthook = "2"
 betterleaks = "v1.6.1"
 
 # Terraform
-terraform = "1"
+"aqua:hashicorp/terraform" = "1"
 # Spell Check
 cspell = "10"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Checklist

### Before Review

- [x] Status checks are passing
- [x] Target branch is `main`

### After Approval

- [x] `mise run tf-apply` has succeeded

## Summary

Switches mise's terraform tool to the `aqua:hashicorp/terraform` backend instead of the asdf backend, and removes the CI workaround that was needed for the asdf backend's install path issue ([jdx/mise-action#175](https://github.com/jdx/mise-action/issues/175)).

## Notes

Closes #122