### PR TITLE
Add fitness-kpi-tracker to Terraform management

### DIFF
--- a/terraform/repositories.tf
+++ b/terraform/repositories.tf
@@ -107,7 +107,6 @@ locals {
     "fitness-kpi-tracker" = {
       description = "Tracking my fitness KPI."
       topics      = ["android"]
-      auto_init   = true
     }
 
     "gh-check-unpinned" = {

--- a/terraform/repositories.tf
+++ b/terraform/repositories.tf
@@ -104,6 +104,12 @@ locals {
       topics      = ["haskell", "elliptic-curves", "ellipse", "algebra"]
     }
 
+    "fitness-kpi-tracker" = {
+      description = "Tracking my fitness KPI."
+      topics      = ["android"]
+      auto_init   = true
+    }
+
     "gh-check-unpinned" = {
       description = "This GitHub CLI extension detects the use of actions in the workflow of repositories under a specific owner (user or organization) that are not SHA-pinned."
       topics      = ["go", "github-cli"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Checklist

### Before Review

- [x] Status checks are passing
- [x] Target branch is `main`

### After Approval

- [ ] `mise run tf-apply` has succeeded

## Summary

Adds `fitness-kpi-tracker` to Terraform management with:

- description: "Tracking my fitness KPI."
- topics: `["android"]`
- all other settings use root defaults (public visibility, branch protection enabled, `auto_init` omitted)

## Notes

The repository does not yet exist on GitHub; it will be created by Terraform.