### PR TITLE
Delete notes from Terraform management

### DIFF
--- a/terraform/repositories.tf
+++ b/terraform/repositories.tf
@@ -200,11 +200,6 @@ locals {
       archived    = true
     }
 
-    "notes" = {
-      description = "Knowledge base and notes"
-      topics      = ["markdown", "notes"]
-    }
-
     "vscode-snippets" = {
       description = "My snippets for Visual Studio Code"
       topics      = ["vscode", "snippets"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Checklist

### Before Review

- [x] Status checks are passing
- [x] Target branch is `main`

### After Approval

- [x] `mise run tf-apply` has succeeded

## Summary

Remove the `notes` entry from `local.repositories`.

**Applying this PR deletes <https://github.com/23prime/notes> on GitHub.** The repository module does not set `archive_on_destroy`, so the repository is destroyed rather than archived — code, issues, pull requests, and releases go with it.

State at the time of the plan: public, not archived, last pushed 2026-08-05.

## Notes

```txt
Plan: 0 to add, 0 to change, 6 to destroy.
```

All six destroyed addresses are under `module.repository["notes"]`:

- `github_repository.this`
- `github_repository_vulnerability_alerts.this[0]`
- `github_repository_dependabot_security_updates.this[0]`
- `github_repository_ruleset.main_branch_protection[0]`
- `github_actions_repository_permissions.this[0]`
- `github_workflow_repository_permissions.this[0]`

`github_repository_pages` and `github_repository_environment` are absent because the entry does not set `enable_pages`.
